### PR TITLE
fix(secrets): detect high-entropy vendor-specific keys in app configuration XML

### DIFF
--- a/secrets/scanner.go
+++ b/secrets/scanner.go
@@ -177,6 +177,19 @@ func addJamfRules(cfg *config.Config) {
 			SecretGroup: 1,
 			Keywords:    []string{"wifi_password", "shared_secret", "vpn_password", "preshared_key"},
 		},
+		{
+			// Catches vendor-specific key names (e.g. LicenseKey, BearerToken) that the
+			// keyword-based jamf-plist-password rule won't match. Scoped to app_configurations/
+			// to limit false positives from bundle IDs and other low-entropy config values.
+			// No Keywords: gitleaks' prefilter trie is built at detector creation so post-init
+			// additions have no effect; Path alone is sufficient to scope this rule.
+			RuleID:      "jamf-appconfig-high-entropy",
+			Description: "High-entropy secret under vendor-specific key in app configuration XML",
+			Regex:       regexp.MustCompile(`(?is)<key>[^<]{1,64}</key>\s*<string>([^<]{8,})</string>`),
+			SecretGroup: 1,
+			Entropy:     4.0,
+			Path:        regexp.MustCompile(`support_files[/\\]app_configurations`),
+		},
 	}
 
 	for _, rule := range jamfRules {

--- a/secrets/scanner_test.go
+++ b/secrets/scanner_test.go
@@ -133,6 +133,74 @@ func TestScanFindsPlistPasswordMultiline(t *testing.T) {
 	}
 }
 
+func TestScanFindsAppConfigVendorSpecificKey(t *testing.T) {
+	dir := t.TempDir()
+
+	sfDir := filepath.Join(dir, "support_files", "app_configurations")
+	if err := os.MkdirAll(sfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Vendor-specific key with a high-entropy license key value
+	content := `<dict>
+<key>LicenseKey</key>
+<string>aB3kQ9mZ2pX7nL5vW8cD1eY4rT6sU0jH</string>
+</dict>
+`
+	if err := os.WriteFile(filepath.Join(sfDir, "VendorApp.xml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := Scan(dir, true)
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	if len(findings) == 0 {
+		t.Fatal("expected finding for high-entropy vendor-specific app config key")
+	}
+
+	f := findings[0]
+	if !f.InSupportFiles {
+		t.Error("expected InSupportFiles=true")
+	}
+	if f.RuleID != "jamf-appconfig-high-entropy" {
+		t.Errorf("RuleID = %q, want %q", f.RuleID, "jamf-appconfig-high-entropy")
+	}
+}
+
+func TestScanSkipsAppConfigLowEntropyValues(t *testing.T) {
+	dir := t.TempDir()
+
+	sfDir := filepath.Join(dir, "support_files", "app_configurations")
+	if err := os.MkdirAll(sfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bundle ID and server URL — low-entropy, should not be flagged
+	content := `<dict>
+<key>BundleIdentifier</key>
+<string>com.company.myapp</string>
+<key>ServerURL</key>
+<string>https://mdm.example.com</string>
+</dict>
+`
+	if err := os.WriteFile(filepath.Join(sfDir, "Config.xml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := Scan(dir, true)
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.RuleID == "jamf-appconfig-high-entropy" {
+			t.Errorf("unexpected high-entropy finding for low-entropy config value: secret=%q", f.Secret)
+		}
+	}
+}
+
 func TestScanFindsPrivateKey(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Adds `jamf-appconfig-high-entropy` rule in `secrets/scanner.go` scoped to `support_files/app_configurations/` that catches secrets under non-standard XML key names (`LicenseKey`, `BearerToken`, `ActivationCode`, `RegistrationCode`, etc.)
- Uses Shannon entropy ≥ 4.0 rather than keyword matching — catches real tokens/license keys (typically 4.5+) while excluding bundle IDs and server URLs (typically < 4.0)
- Adds two new tests: positive case (high-entropy vendor key is caught) and negative case (low-entropy config values are not flagged)

## Root cause

`jamf-plist-password` only matched a fixed set of XML key names. Vendor-specific keys silently passed the scan.

The new rule has no `Keywords` field — gitleaks builds its Aho-Corasick prefilter trie at `NewDetectorDefaultConfig()`, so keywords added post-init are not in the trie and rules depending on them never fire. `Path` scoping to `app_configurations/` is sufficient to limit scope.

## Test plan

- [x] `TestScanFindsAppConfigVendorSpecificKey` — `LicenseKey` with a high-entropy value is caught by the new rule
- [x] `TestScanSkipsAppConfigLowEntropyValues` — bundle IDs and server URLs below entropy threshold are not flagged
- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l` — no formatting changes
- [x] `go fix ./...` — no changes

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)