### PR TITLE
fix(platform,protect): don't crash when a filtered discovery yields zero resources

### DIFF
--- a/platform/pipeline.go
+++ b/platform/pipeline.go
@@ -207,6 +207,16 @@ func RunDiscoveryAndGenerate(opts *PipelineOptions) (*IntermediateResult, error)
 		return nil, fmt.Errorf("terraform query: %w", queryErr)
 	}
 
+	// terraform query never creates generatedFile when every selected list
+	// block returns zero resources. Every step below (label renaming, registry
+	// population, benchmark stripping, ...) assumes the file exists, so restore
+	// that invariant with an empty file instead of letting os.ReadFile fail.
+	if _, statErr := os.Stat(generatedFile); os.IsNotExist(statErr) {
+		if err := os.WriteFile(generatedFile, nil, 0644); err != nil {
+			return nil, fmt.Errorf("creating empty generated file: %w", err)
+		}
+	}
+
 	// 3b. Discover Jamf Connect config-profile links via the federated pro SDK.
 	// jamfplatform_pro_jamf_connect has no list resource, so it is not
 	// query-discoverable; the SDK enumerates the linked profiles and we write

--- a/protect/pipeline.go
+++ b/protect/pipeline.go
@@ -94,6 +94,17 @@ func RunPipeline(opts *PipelineOptions) (*postprocess.FixResult, error) {
 	if err := terraform.QueryWithEvents(opts.OutputDir, generatedFile, eventsFile, protectEnv); err != nil {
 		return nil, fmt.Errorf("terraform query: %w", err)
 	}
+
+	// terraform query never creates generatedFile when every selected list
+	// block returns zero resources. Every step below (singleton merge, label
+	// renaming, registry population, ...) assumes the file exists, so restore
+	// that invariant with an empty file instead of letting os.ReadFile fail.
+	if _, statErr := os.Stat(generatedFile); os.IsNotExist(statErr) {
+		if err := os.WriteFile(generatedFile, nil, 0644); err != nil {
+			return nil, fmt.Errorf("creating empty generated file: %w", err)
+		}
+	}
+
 	idToName, err := ParseQueryEvents(eventsFile)
 	if err != nil {
 		if !opts.Quiet {


### PR DESCRIPTION
## Summary

- `terraform query -generate-config-out` never creates `generated.tf` when every selected `list` block returns zero resources. `-include-resources` (or `-exclude-resources`) narrowed to a type with no matches on the tenant crashed the whole pipeline with a raw `open .../generated.tf: no such file or directory` instead of a clean message.
- Restores the invariant that `generated.tf` always exists after the query step, in both the `platform` and `protect` pipelines (they share the same downstream label-renaming/registry code that assumes the file exists).

Fixes #25

## Test plan

- [x] `go test ./...` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Live-tested against a Jamf Platform EU tenant:
  - `-include-resources site` (0 sites on tenant) — before: crash, exit 1; after: `✓ Terraform project generated`, exit 0
  - `-include-resources script` (102 scripts) — unaffected, still generates 102 resources + 102 import blocks