### PR TITLE
feat(protect): support unified logging filter sets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,12 @@ jamformer is a CLI tool that converts a Jamf instance into a structured Terrafor
 ### Jamf Protect Pipeline (protect/pipeline.go → RunPipeline)
 
 1. **importgen** — Writes `provider.tf`, `variables.tf`, `terraform.tfvars` for the Jamf Protect provider (OAuth2 only)
-2. **protect** — Generates `query.tfquery.hcl` with `list {}` blocks for 13 listable resource types + `singletons_import.tf` with `import {}` blocks for 3 singleton resources
+2. **protect** — Generates `query.tfquery.hcl` with `list {}` blocks for 14 listable resource types + `singletons_import.tf` with `import {}` blocks for 3 singleton resources
 3. **terraform** — Runs `terraform init`, then `terraform query -generate-config-out=generated.tf` (list resources), then `terraform plan -generate-config-out=singletons_generated.tf` (singletons) — all via tfexec
 4. **protect** — Renames auto-generated labels (`all_0`, `all_1`) to friendly names derived from resource `name`/`email` attributes, then populates **registry** from import blocks in the generated HCL
 5. **postprocess** — Strips null attributes, rewrites literal IDs to cross-resource Terraform references, splits into per-type files (no script/profile/package extraction for Protect)
+
+Unified logging filters reach endpoints through a two-hop chain, both hops rewritten as references: `jamfprotect_unified_logging_filter_set.filters` holds filter UUIDs, and `jamfprotect_plan.unified_logging_filter_sets` assigns sets to a plan. `enabled` on a filter is retained by the provider for backwards compatibility but no longer controls delivery. Filter sets require `jamfprotect-go-sdk` v0.8.0+ and provider v0.11.0+.
 
 ### Jamf Platform Pipeline (platform/pipeline.go → RunPipeline)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.12.1
-	github.com/Jamf-Concepts/jamfprotect-go-sdk v0.7.1
+	github.com/Jamf-Concepts/jamfprotect-go-sdk v0.8.0
 	github.com/deploymenttheory/go-api-sdk-jamfpro v1.52.1
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hc-install v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BobuSumisu/aho-corasick v1.0.3 h1:uuf+JHwU9CHP2Vx+wAy6jcksJThhJS9ehR8
 github.com/BobuSumisu/aho-corasick v1.0.3/go.mod h1:hm4jLcvZKI2vRF2WDU1N4p/jpWtpOzp3nLmi9AzX/XE=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.12.1 h1:H+zGH9/p2yu1wbMZ0rorVYHrZHPQYJDbey+zvFy1aGU=
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.12.1/go.mod h1:v96UekyoXOw61BzxVl8I3cdUinpCm6MY5K1kfLaEuG8=
-github.com/Jamf-Concepts/jamfprotect-go-sdk v0.7.1 h1:/i+tnP1KHv+ZZEyiKFyLeUs3vTB4dzT9s2M31rQqwE0=
-github.com/Jamf-Concepts/jamfprotect-go-sdk v0.7.1/go.mod h1:wS0UZcnQBgn9UuyOp95tgf+dg92vGCu9iU5f0gAZjbg=
+github.com/Jamf-Concepts/jamfprotect-go-sdk v0.8.0 h1:AiP8KiPpTMLnAEY4E9T8PtBOihVMjeQ3/lnLcpbR/yc=
+github.com/Jamf-Concepts/jamfprotect-go-sdk v0.8.0/go.mod h1:IoRB8uP1p0XxxFr/ZbP4+HSmoYd66LES1l0xev0GaxM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=

--- a/postprocess/hcl.go
+++ b/postprocess/hcl.go
@@ -3,6 +3,7 @@
 package postprocess
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -45,21 +46,50 @@ func tokensStringValue(tokens hclwrite.Tokens) string {
 // extractListValues extracts string or numeric values from a list expression,
 // preserving a leading unary minus on negative numbers (see tokensStringValue).
 func extractListValues(attr *hclwrite.Attribute) []string {
+	literals := extractListLiterals(attr)
+	values := make([]string, len(literals))
+	for i, l := range literals {
+		values[i] = l.Val
+	}
+	return values
+}
+
+// listLiteral is one element of a list expression, retaining whether the source
+// literal was quoted. An unresolved element has to be re-emitted with its
+// original literal kind: quoting a number would change the element type of a
+// number-typed list, and leaving a string bare produces invalid HCL.
+type listLiteral struct {
+	Val    string
+	Quoted bool
+}
+
+// extractListLiterals extracts the elements of a list expression along with the
+// kind of literal each one was.
+func extractListLiterals(attr *hclwrite.Attribute) []listLiteral {
 	tokens := attr.Expr().BuildTokens(nil)
-	var values []string
+	var values []listLiteral
 	for i, tok := range tokens {
 		switch tok.Type {
 		case hclsyntax.TokenQuotedLit:
-			values = append(values, string(tok.Bytes))
+			values = append(values, listLiteral{Val: string(tok.Bytes), Quoted: true})
 		case hclsyntax.TokenNumberLit:
 			if i > 0 && tokens[i-1].Type == hclsyntax.TokenMinus {
-				values = append(values, "-"+string(tok.Bytes))
+				values = append(values, listLiteral{Val: "-" + string(tok.Bytes)})
 			} else {
-				values = append(values, string(tok.Bytes))
+				values = append(values, listLiteral{Val: string(tok.Bytes)})
 			}
 		}
 	}
 	return values
+}
+
+// unresolvedListLiteral renders an unresolved list element, preserving the
+// original literal kind so the result stays valid, correctly-typed HCL.
+func unresolvedListLiteral(l listLiteral) string {
+	if l.Quoted {
+		return fmt.Sprintf("%q", l.Val)
+	}
+	return l.Val
 }
 
 // referenceTokens creates HCL tokens for a resource attribute reference like

--- a/postprocess/references_test.go
+++ b/postprocess/references_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Jamf-Concepts/jamformer/protect"
 	"github.com/Jamf-Concepts/jamformer/registry"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -1555,6 +1556,57 @@ func TestProtectUnifiedLoggingFilterSetEmptyFilters(t *testing.T) {
 	}
 	if strings.Contains(result, "TODO: unresolved reference") {
 		t.Errorf("Empty filters list should not produce an unresolved-reference TODO, got:\n%s", result)
+	}
+}
+
+// TestUnresolvedListLiteralsStayValidHCL covers an unresolvable ID inside a list
+// attribute. A string element must be re-quoted (a bare UUID parses as an
+// identifier and makes the file invalid HCL), while a numeric element must stay
+// bare so a number-typed list keeps its element type.
+func TestUnresolvedListLiteralsStayValidHCL(t *testing.T) {
+	reg := setupProtectRegistry()
+	rules := protect.DefaultRules()
+
+	// String IDs: the member filters were never discovered, so neither resolves.
+	src := `resource "jamfprotect_unified_logging_filter_set" "test" {
+  name    = "Endpoint Diagnostics"
+  filters = ["4c8552c0-8347-43fb-b74b-eda602d02e15", "ulf-111"]
+}`
+	f := parseHCLRef(t, src)
+	body := refBlockBody(t, f)
+	applyRules(body, "jamfprotect_unified_logging_filter_set", rules, reg)
+	result := string(f.Bytes())
+
+	if !strings.Contains(result, `"4c8552c0-8347-43fb-b74b-eda602d02e15", # TODO: unresolved reference`) {
+		t.Errorf("expected unresolved string element re-quoted, got:\n%s", result)
+	}
+	// The resolvable one still becomes a reference.
+	if !strings.Contains(result, "jamfprotect_unified_logging_filter.time_machine.id") {
+		t.Errorf("expected resolvable element rewritten, got:\n%s", result)
+	}
+	// The whole file must still parse.
+	if _, diags := hclwrite.ParseConfig([]byte(result), "test.tf", hcl.Pos{Line: 1, Column: 1}); diags.HasErrors() {
+		t.Errorf("rewritten HCL does not parse: %s\n%s", diags.Error(), result)
+	}
+	if _, diags := hclsyntax.ParseConfig([]byte(result), "test.tf", hcl.Pos{Line: 1, Column: 1}); diags.HasErrors() {
+		t.Errorf("rewritten HCL is not valid syntax: %s\n%s", diags.Error(), result)
+	}
+
+	// Numeric IDs must not gain quotes.
+	numSrc := `resource "jamfprotect_user" "test" {
+  email    = "test@example.com"
+  role_ids = [999]
+}`
+	nf := parseHCLRef(t, numSrc)
+	nbody := refBlockBody(t, nf)
+	applyRules(nbody, "jamfprotect_user", rules, reg)
+	numResult := string(nf.Bytes())
+
+	if !strings.Contains(numResult, "999, # TODO: unresolved reference") {
+		t.Errorf("expected unresolved numeric element left bare, got:\n%s", numResult)
+	}
+	if strings.Contains(numResult, `"999"`) {
+		t.Errorf("numeric element must not be quoted, got:\n%s", numResult)
 	}
 }
 

--- a/postprocess/references_test.go
+++ b/postprocess/references_test.go
@@ -1399,6 +1399,9 @@ func setupProtectRegistry() *registry.Registry {
 	reg.Register("jamfprotect_exception_set", "def-456", "jamfprotect_exception_set.trusted_apps")
 	reg.Register("jamfprotect_telemetry", "tel-789", "jamfprotect_telemetry.default_telemetry")
 	reg.Register("jamfprotect_removable_storage_control_set", "rsc-012", "jamfprotect_removable_storage_control_set.block_usb")
+	reg.Register("jamfprotect_unified_logging_filter", "ulf-111", "jamfprotect_unified_logging_filter.time_machine")
+	reg.Register("jamfprotect_unified_logging_filter", "ulf-222", "jamfprotect_unified_logging_filter.screen_sharing")
+	reg.Register("jamfprotect_unified_logging_filter_set", "ulfs-333", "jamfprotect_unified_logging_filter_set.endpoint_diagnostics")
 	return reg
 }
 
@@ -1513,6 +1516,48 @@ func TestProtectAnalyticSetManagedAnalyticReference(t *testing.T) {
 	}
 }
 
+func TestProtectUnifiedLoggingFilterSetFiltersReference(t *testing.T) {
+	reg := setupProtectRegistry()
+	rules := protect.DefaultRules()
+	src := `resource "jamfprotect_unified_logging_filter_set" "test" {
+  name    = "Endpoint Diagnostics"
+  filters = ["ulf-111", "ulf-222"]
+}`
+	f := parseHCLRef(t, src)
+	body := refBlockBody(t, f)
+	applyRules(body, "jamfprotect_unified_logging_filter_set", rules, reg)
+	result := string(f.Bytes())
+
+	if !strings.Contains(result, "jamfprotect_unified_logging_filter.time_machine.id") {
+		t.Errorf("Expected filters to reference time_machine, got:\n%s", result)
+	}
+	if !strings.Contains(result, "jamfprotect_unified_logging_filter.screen_sharing.id") {
+		t.Errorf("Expected filters to reference screen_sharing, got:\n%s", result)
+	}
+}
+
+// TestProtectUnifiedLoggingFilterSetEmptyFilters covers a filter set with no
+// members — valid per the provider schema, and must survive rewriting untouched.
+func TestProtectUnifiedLoggingFilterSetEmptyFilters(t *testing.T) {
+	reg := setupProtectRegistry()
+	rules := protect.DefaultRules()
+	src := `resource "jamfprotect_unified_logging_filter_set" "test" {
+  name    = "Placeholder Set"
+  filters = []
+}`
+	f := parseHCLRef(t, src)
+	body := refBlockBody(t, f)
+	applyRules(body, "jamfprotect_unified_logging_filter_set", rules, reg)
+	result := string(f.Bytes())
+
+	if !strings.Contains(result, "filters = []") {
+		t.Errorf("Expected empty filters list preserved, got:\n%s", result)
+	}
+	if strings.Contains(result, "TODO: unresolved reference") {
+		t.Errorf("Empty filters list should not produce an unresolved-reference TODO, got:\n%s", result)
+	}
+}
+
 func TestProtectPlanReferences(t *testing.T) {
 	reg := setupProtectRegistry()
 	rules := protect.DefaultRules()
@@ -1523,6 +1568,7 @@ func TestProtectPlanReferences(t *testing.T) {
   telemetry                    = "tel-789"
   removable_storage_control_set = "rsc-012"
   analytic_sets                = ["79e0a2a0-3af2-4e0b-8148-1f9c129bfd85"]
+  unified_logging_filter_sets  = ["ulfs-333"]
 }`
 	f := parseHCLRef(t, src)
 	body := refBlockBody(t, f)
@@ -1543,6 +1589,9 @@ func TestProtectPlanReferences(t *testing.T) {
 	}
 	if !strings.Contains(result, "jamfprotect_analytic_set.default.id") {
 		t.Errorf("Expected analytic_sets to reference default, got:\n%s", result)
+	}
+	if !strings.Contains(result, "jamfprotect_unified_logging_filter_set.endpoint_diagnostics.id") {
+		t.Errorf("Expected unified_logging_filter_sets to reference endpoint_diagnostics, got:\n%s", result)
 	}
 }
 

--- a/postprocess/rewrite.go
+++ b/postprocess/rewrite.go
@@ -249,7 +249,7 @@ func rewriteListAttribute(body *hclwrite.Body, rule ReferenceRule, reg *registry
 		return false
 	}
 
-	values := extractListValues(attr)
+	values := extractListLiterals(attr)
 	if len(values) == 0 {
 		return false
 	}
@@ -258,7 +258,8 @@ func rewriteListAttribute(body *hclwrite.Body, rule ReferenceRule, reg *registry
 	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")})
 	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")})
 
-	for _, val := range values {
+	for _, literal := range values {
+		val := literal.Val
 		resolved := false
 		// Preserve "none" sentinels verbatim (never a real reference).
 		if isSentinelID(val) {
@@ -276,8 +277,10 @@ func rewriteListAttribute(body *hclwrite.Body, rule ReferenceRule, reg *registry
 			}
 		}
 		if !resolved {
-			// Keep as literal with TODO comment
-			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: fmt.Appendf(nil, "    %s, # TODO: unresolved reference", val)})
+			// Keep as literal with TODO comment, re-quoting a string element so
+			// the list stays valid HCL (a bare UUID parses as an identifier and
+			// trips "Missing item separator").
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: fmt.Appendf(nil, "    %s, # TODO: unresolved reference", unresolvedListLiteral(literal))})
 			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")})
 		}
 	}

--- a/protect/query.go
+++ b/protect/query.go
@@ -30,6 +30,7 @@ var listableResourceTypes = map[string]string{
 	"roles":                          "jamfprotect_role",
 	"telemetry":                      "jamfprotect_telemetry",
 	"unified_logging_filters":        "jamfprotect_unified_logging_filter",
+	"unified_logging_filter_sets":    "jamfprotect_unified_logging_filter_set",
 	"users":                          "jamfprotect_user",
 }
 

--- a/protect/resources.go
+++ b/protect/resources.go
@@ -26,6 +26,7 @@ var Resources = []ResourceDef{
 	{FilterKey: "action_configurations", DisplayName: "Action Configurations", TFType: "jamfprotect_action_configuration", OutputFile: "action_configurations.tf"},
 	{FilterKey: "telemetry", DisplayName: "Telemetry", TFType: "jamfprotect_telemetry", OutputFile: "telemetry.tf"},
 	{FilterKey: "unified_logging_filters", DisplayName: "Unified Logging Filters", TFType: "jamfprotect_unified_logging_filter", OutputFile: "unified_logging_filters.tf"},
+	{FilterKey: "unified_logging_filter_sets", DisplayName: "Unified Logging Filter Sets", TFType: "jamfprotect_unified_logging_filter_set", OutputFile: "unified_logging_filter_sets.tf"},
 	{FilterKey: "custom_prevent_lists", DisplayName: "Custom Prevent Lists", TFType: "jamfprotect_custom_prevent_list", OutputFile: "custom_prevent_lists.tf"},
 	{FilterKey: "removable_storage_control_sets", DisplayName: "Removable Storage Control Sets", TFType: "jamfprotect_removable_storage_control_set", OutputFile: "removable_storage_control_sets.tf"},
 	{FilterKey: "plans", DisplayName: "Plans", TFType: "jamfprotect_plan", OutputFile: "plans.tf"},
@@ -96,6 +97,14 @@ func DefaultRules() []postprocess.ReferenceRule {
 			TargetAttr:   "id",
 			IsList:       true,
 		},
+		// Unified Logging Filter Set -> Unified Logging Filter references
+		{
+			ResourceType: "jamfprotect_unified_logging_filter_set",
+			AttrName:     "filters",
+			TargetTypes:  []string{"jamfprotect_unified_logging_filter"},
+			TargetAttr:   "id",
+			IsList:       true,
+		},
 		// Plan -> Action Configuration reference
 		{
 			ResourceType: "jamfprotect_plan",
@@ -130,6 +139,14 @@ func DefaultRules() []postprocess.ReferenceRule {
 			ResourceType: "jamfprotect_plan",
 			AttrName:     "analytic_sets",
 			TargetTypes:  []string{"jamfprotect_analytic_set"},
+			TargetAttr:   "id",
+			IsList:       true,
+		},
+		// Plan -> Unified Logging Filter Set references
+		{
+			ResourceType: "jamfprotect_plan",
+			AttrName:     "unified_logging_filter_sets",
+			TargetTypes:  []string{"jamfprotect_unified_logging_filter_set"},
 			TargetAttr:   "id",
 			IsList:       true,
 		},

--- a/protect/resources_test.go
+++ b/protect/resources_test.go
@@ -21,6 +21,7 @@ func TestProtectTypeToFileMap(t *testing.T) {
 		"jamfprotect_role",
 		"jamfprotect_telemetry",
 		"jamfprotect_unified_logging_filter",
+		"jamfprotect_unified_logging_filter_set",
 		"jamfprotect_user",
 		"jamfprotect_change_management",
 		"jamfprotect_data_forwarding",
@@ -64,11 +65,64 @@ func TestProtectDefaultRulesCount(t *testing.T) {
 		"jamfprotect_user",
 		"jamfprotect_api_client",
 		"jamfprotect_analytic_set",
+		"jamfprotect_unified_logging_filter_set",
 		"jamfprotect_plan",
 	}
 	for _, rt := range expected {
 		if !ruleTypes[rt] {
 			t.Errorf("expected DefaultRules to include rules for %q", rt)
+		}
+	}
+}
+
+// TestProtectDefaultRulesHaveValidTypes verifies every rule's source and target
+// resource types are types the Protect pipeline actually knows about, so a typo
+// in a rule fails here rather than silently never matching.
+func TestProtectDefaultRulesHaveValidTypes(t *testing.T) {
+	knownTypes := TypeToFileMap()
+	for _, rule := range DefaultRules() {
+		if _, ok := knownTypes[rule.ResourceType]; !ok {
+			t.Errorf("rule references unknown source type: %q", rule.ResourceType)
+		}
+		for _, tt := range rule.TargetTypes {
+			if _, ok := knownTypes[tt]; !ok {
+				t.Errorf("rule for %s.%s references unknown target type: %q", rule.ResourceType, rule.AttrName, tt)
+			}
+		}
+	}
+}
+
+// TestProtectListableAndSingletonTypesAreDefined verifies every resource type the
+// query/singleton tables reference has a Resources entry (and therefore an output
+// file), so a new listable type can't be discovered into a file that doesn't exist.
+func TestProtectListableAndSingletonTypesAreDefined(t *testing.T) {
+	knownTypes := TypeToFileMap()
+	filterKeys := ValidFilterNames()
+
+	for filterKey, resourceType := range listableResourceTypes {
+		if _, ok := knownTypes[resourceType]; !ok {
+			t.Errorf("listable type %q (%s) has no Resources entry", resourceType, filterKey)
+		}
+		if _, ok := filterKeys[filterKey]; !ok {
+			t.Errorf("listable filter key %q has no Resources entry", filterKey)
+		}
+	}
+
+	for filterKey, singleton := range singletonResources {
+		if _, ok := knownTypes[singleton.ResourceType]; !ok {
+			t.Errorf("singleton type %q (%s) has no Resources entry", singleton.ResourceType, filterKey)
+		}
+		if _, ok := filterKeys[filterKey]; !ok {
+			t.Errorf("singleton filter key %q has no Resources entry", filterKey)
+		}
+	}
+
+	// Every Resources entry must be reachable as either listable or singleton.
+	for _, r := range Resources {
+		_, listable := listableResourceTypes[r.FilterKey]
+		_, singleton := singletonResources[r.FilterKey]
+		if !listable && !singleton {
+			t.Errorf("Resources entry %q (%s) is neither listable nor a singleton", r.FilterKey, r.TFType)
 		}
 	}
 }

--- a/protect/unified_logging_test.go
+++ b/protect/unified_logging_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026, Jamf Software LLC
+
+package protect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamformer/postprocess"
+	"github.com/Jamf-Concepts/jamformer/registry"
+)
+
+// generatedULFS mirrors what terraform query emits for unified logging filters,
+// filter sets, and the plan that assigns them: auto-generated "all_N" labels,
+// nested identity { id } import blocks, and raw UUIDs in the cross-resource
+// attributes.
+const generatedULFS = `
+resource "jamfprotect_unified_logging_filter" "all_0" {
+  name        = "Time Machine Activity"
+  description = "Captures Time Machine backup activity"
+  filter      = "subsystem == \"com.apple.TimeMachine\""
+  enabled     = true
+  tags        = ["backup"]
+}
+
+import {
+  identity = {
+    id = "ulf-aaa"
+  }
+  to = jamfprotect_unified_logging_filter.all_0
+}
+
+resource "jamfprotect_unified_logging_filter" "all_1" {
+  name        = "Screen Sharing Sessions"
+  description = "Captures screen sharing connections"
+  filter      = "subsystem == \"com.apple.screensharing\""
+  enabled     = true
+  tags        = ["remote-access"]
+}
+
+import {
+  identity = {
+    id = "ulf-bbb"
+  }
+  to = jamfprotect_unified_logging_filter.all_1
+}
+
+resource "jamfprotect_unified_logging_filter_set" "all_0" {
+  name        = "Endpoint Diagnostics"
+  description = "Diagnostic log capture"
+  filters     = ["ulf-aaa", "ulf-bbb"]
+}
+
+import {
+  identity = {
+    id = "ulfs-ccc"
+  }
+  to = jamfprotect_unified_logging_filter_set.all_0
+}
+
+resource "jamfprotect_plan" "all_0" {
+  name                        = "Diagnostics Plan"
+  unified_logging_filter_sets = ["ulfs-ccc"]
+}
+
+import {
+  identity = {
+    id = "plan-ddd"
+  }
+  to = jamfprotect_plan.all_0
+}
+`
+
+// TestUnifiedLoggingFilterSetEndToEnd runs the post-query half of the Protect
+// pipeline (label renaming → registry population → reference rewriting → file
+// splitting) over realistic terraform query output, verifying that filter set
+// membership and plan assignment resolve to cross-resource references rather
+// than staying as literal UUIDs.
+func TestUnifiedLoggingFilterSetEndToEnd(t *testing.T) {
+	prevQuiet := postprocess.Quiet
+	postprocess.Quiet = true
+	t.Cleanup(func() { postprocess.Quiet = prevQuiet })
+
+	dir := t.TempDir()
+	genFile := filepath.Join(dir, "generated.tf")
+	if err := os.WriteFile(genFile, []byte(generatedULFS), 0644); err != nil {
+		t.Fatalf("writing generated.tf: %v", err)
+	}
+
+	if err := RenameLabelsWithEvents(genFile, nil); err != nil {
+		t.Fatalf("RenameLabelsWithEvents() error: %v", err)
+	}
+
+	reg := registry.New()
+	if err := PopulateRegistryFromGenerated(genFile, reg); err != nil {
+		t.Fatalf("PopulateRegistryFromGenerated() error: %v", err)
+	}
+
+	// Labels must be renamed before registry population, otherwise the filter
+	// and the filter set both register under "all_0" and collide.
+	if addr, ok := reg.Resolve("jamfprotect_unified_logging_filter", "ulf-aaa"); !ok {
+		t.Fatal("filter ulf-aaa not registered")
+	} else if addr != "jamfprotect_unified_logging_filter.time_machine_activity" {
+		t.Errorf("unexpected filter address: %s", addr)
+	}
+	if addr, ok := reg.Resolve("jamfprotect_unified_logging_filter_set", "ulfs-ccc"); !ok {
+		t.Fatal("filter set ulfs-ccc not registered")
+	} else if addr != "jamfprotect_unified_logging_filter_set.endpoint_diagnostics" {
+		t.Errorf("unexpected filter set address: %s", addr)
+	}
+
+	if err := postprocess.Process(dir, genFile, reg, &postprocess.ProcessOptions{
+		TypeToFileMap: TypeToFileMap(),
+		Rules:         DefaultRules(),
+	}); err != nil {
+		t.Fatalf("postprocess.Process() error: %v", err)
+	}
+
+	readFile := func(name string) string {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		return string(data)
+	}
+
+	// Filter set membership resolves to both member filters.
+	setFile := readFile("unified_logging_filter_sets.tf")
+	for _, want := range []string{
+		"jamfprotect_unified_logging_filter.time_machine_activity.id",
+		"jamfprotect_unified_logging_filter.screen_sharing_sessions.id",
+	} {
+		if !strings.Contains(setFile, want) {
+			t.Errorf("unified_logging_filter_sets.tf missing %s, got:\n%s", want, setFile)
+		}
+	}
+	if strings.Contains(setFile, `"ulf-aaa"`) || strings.Contains(setFile, `"ulf-bbb"`) {
+		t.Errorf("filter set still holds literal filter UUIDs:\n%s", setFile)
+	}
+
+	// Plan assignment resolves to the filter set.
+	planFile := readFile("plans.tf")
+	if !strings.Contains(planFile, "jamfprotect_unified_logging_filter_set.endpoint_diagnostics.id") {
+		t.Errorf("plans.tf missing filter set reference, got:\n%s", planFile)
+	}
+	if strings.Contains(planFile, `"ulfs-ccc"`) {
+		t.Errorf("plan still holds literal filter set UUID:\n%s", planFile)
+	}
+
+	// Filters land in their own file, keeping the two types separate despite
+	// the shared resource-type prefix.
+	filterFile := readFile("unified_logging_filters.tf")
+	if !strings.Contains(filterFile, `resource "jamfprotect_unified_logging_filter" "time_machine_activity"`) {
+		t.Errorf("unified_logging_filters.tf missing renamed filter, got:\n%s", filterFile)
+	}
+	if strings.Contains(filterFile, `resource "jamfprotect_unified_logging_filter_set"`) {
+		t.Errorf("filter set leaked into unified_logging_filters.tf:\n%s", filterFile)
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds support for Jamf Protect **unified logging filter sets**, the new capability in `jamfprotect-go-sdk` v0.8.0, and bumps the SDK from v0.7.1 to v0.8.0.

Jamf Protect changed how unified logging filters reach endpoints: a filter is now delivered only when it belongs to a filter set that is assigned to a plan, mirroring how analytic sets scope analytics. A filter's own `enabled` flag is retained by the provider for backwards compatibility but no longer controls delivery.

That makes it a two-hop reference chain, and both hops are now resolved to cross-resource references rather than left as literal UUIDs:

| Source | Attribute | Target |
| --- | --- | --- |
| `jamfprotect_unified_logging_filter_set` | `filters` | `jamfprotect_unified_logging_filter` |
| `jamfprotect_plan` | `unified_logging_filter_sets` | `jamfprotect_unified_logging_filter_set` |

`jamfprotect_unified_logging_filter_set` is added as a listable type (output: `unified_logging_filter_sets.tf`). Everything else — registry population, label renaming, file splitting, `-list-resources`, `-include-resources` — is table-driven and picked the type up with no further changes.

Requires provider **v0.11.0+**, which already ships the filter set list resource.

### Second commit: unrelated pre-existing bug found while verifying

`1c56624` fixes a bug in the shared reference-rewriting path, found by running `terraform validate` over a partial export. An unresolvable ID inside a *list* attribute was re-emitted **unquoted**:

```hcl
exception_sets = [
  4c8552c0-8347-43fb-b74b-eda602d02e15, # TODO: unresolved reference
]
```

Terraform rejects this with `Missing item separator` — the bare UUID parses as an identifier. Consequences were wider than the one attribute: it also silently suppressed `terraform fmt` (leaving the rest of the file misindented) and failed `terraform validate` for the whole project.

Numeric IDs happened to remain valid HCL, which is why this went unnoticed — the affected rules are mostly Jamf Pro integer IDs. It shows up on any provider with string IDs whenever a referenced type is not discovered, which `-include-resources` makes routine. The single-attribute path already quoted correctly via `todoTokens`, as did the sentinel branch of the list path; only the unresolved list element did not.

The fix tracks whether each element's literal was quoted and re-emits it in kind, so strings are quoted and numbers stay bare (quoting a number would change the element type of a number-typed list).

## Type of Change

- [x] Bug fix
- [x] Enhancement/feature
- [x] Documentation update
- [ ] Refactoring/code cleanup
- [ ] CI/CD changes
- [ ] Other (please describe):

## Testing

### Unit Tests

- [x] Added unit tests for new features or bug fixes
- [x] All unit tests pass locally (`make test`)

New tests:

- Filter set → filter and plan → filter set reference rewriting, plus the empty-`filters` case (valid per the provider schema, and must not emit a spurious unresolved-reference TODO).
- `TestUnifiedLoggingFilterSetEndToEnd` — runs the whole post-query pipeline (label renaming → registry population → reference rewriting → file splitting) over realistic `terraform query` output, asserting literals are gone and that the two similarly-prefixed types do not leak into each other's files.
- `TestUnresolvedListLiteralsStayValidHCL` — regression test for the bug above, asserting a string element is re-quoted, a numeric element is not, and the result parses as valid HCL.
- Two guard tests that would have caught a mistake in this PR: every reference rule names a known source/target type, and every listable/singleton type has a `Resources` entry (and vice versa), so a new type can't be discovered into an output file that doesn't exist.

Also verified locally with the exact CI commands: `go test -cover -count=1 -race -shuffle=on`, `go vet`, `go build`, `gofmt -l`, `go mod tidy` (stable), and `golangci-lint run ./...` → 0 issues.

### Manual Testing

- [x] Tested `jamformer` against a real Jamf instance
- [x] Ensure a Terraform project is created with expected resources and references
- [x] Verify secret scanning detects embedded credentials and interactive remediation works

Tested against a live Jamf Protect sandbox tenant. The tenant had no unified logging filters or filter sets, so temporary fixtures were created via the SDK (two filters, one set containing both, and a **new** plan cloned from an existing plan's shape with the set assigned — no pre-existing object was modified). All fixtures were deleted afterwards and the tenant verified back at its exact baseline.

Full export with fixtures present: **335 resources across 14 types**, `terraform validate` → `Success! The configuration is valid.`, `terraform fmt -check` clean, no validation auto-fixes required.

Generated output, with both hops resolved from real tenant data:

```hcl
resource "jamfprotect_unified_logging_filter_set" "jamformer_fixture_set" {
  provider = jamfprotect

  description = "jamformer fixture - safe to delete"
  filters = [
    jamfprotect_unified_logging_filter.jamformer_fixture_time_machine.id,
    jamfprotect_unified_logging_filter.jamformer_fixture_screen_sharing.id,
  ]
  name = "jamformer-fixture Set"
}

resource "jamfprotect_plan" "jamformer_fixture_plan" {
  # ...
  unified_logging_filter_sets = [
    jamfprotect_unified_logging_filter_set.jamformer_fixture_set.id,
  ]
}
```

Import blocks carry the real UUIDs, and auto-generated `all_N` labels were renamed from the resource `name` attribute as expected.

Secret scanning ran on every export and reported no findings (these resource types carry log predicates, not credentials).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Documentation: `CLAUDE.md` updated (listable type count 13 → 14, plus a note on the two-hop delivery chain and version requirements). `README.md` needs no change — it deliberately defers resource enumeration to `-list-resources`, which picks the new type up automatically.

## Additional Context

Both commits are individually green and bisectable — the feature commit was verified to pass with the bug fix set aside.

Note on naming: `jamfprotect_unified_logging_filter` and `jamfprotect_unified_logging_filter_set` share a type-name prefix, but all resource-type matching in `postprocess` is exact equality, so there is no substring hazard. A test asserts the two types split into separate files.

## Related Issues

<!-- Link any related issues here using #issue_number -->
